### PR TITLE
feat: initial values

### DIFF
--- a/src/Battery.ts
+++ b/src/Battery.ts
@@ -14,11 +14,18 @@ type NavigatorWithBattery = Navigator & {
 
 const events = ['chargingchange', 'chargingtimechange', 'dischargingtimechange', 'levelchange'];
 
-export function useBattery() {
-  const isCharging = ref(false);
-  const chargingTime = ref(0);
-  const dischargingTime = ref(0);
-  const level = ref(1);
+interface UseBatteryOptions {
+  isCharging?: boolean;
+  chargingTime?: number;
+  dischargingTime?: number;
+  level?: number;
+}
+
+export function useBattery(opts?: UseBatteryOptions) {
+  const isCharging = ref(opts?.isCharging ?? false);
+  const chargingTime = ref(opts?.chargingTime ?? 0);
+  const dischargingTime = ref(opts?.dischargingTime ?? 0);
+  const level = ref(opts?.level ?? 0);
   const isSupported = ref(false);
 
   function updateBatteryInfo(this: BatteryManager) {

--- a/src/HardwareConcurrency.ts
+++ b/src/HardwareConcurrency.ts
@@ -2,7 +2,7 @@ import { ref, onMounted, readonly } from 'vue';
 import { isServer } from './utils';
 
 export function useHardwareConcurrency(initialConcurrency?: number) {
-  const concurrency = ref(initialConcurrency ?? 1);
+  const concurrency = ref(initialConcurrency ?? undefined);
   const isSupported = ref(false);
 
   function resolveConcurrency() {

--- a/src/HardwareConcurrency.ts
+++ b/src/HardwareConcurrency.ts
@@ -1,8 +1,8 @@
 import { ref, onMounted, readonly } from 'vue';
 import { isServer } from './utils';
 
-export function useHardwareConcurrency() {
-  const concurrency = ref(0);
+export function useHardwareConcurrency(initialConcurrency?: number) {
+  const concurrency = ref(initialConcurrency ?? 1);
   const isSupported = ref(false);
 
   function resolveConcurrency() {

--- a/src/Memory.ts
+++ b/src/Memory.ts
@@ -1,11 +1,18 @@
 import { ref, onMounted, readonly, Ref } from 'vue';
 import { isServer } from './utils';
 
-export function useMemoryStatus() {
-  const deviceMemory = ref(0);
-  const totalJSHeapSize: Ref<undefined | number> = ref(undefined);
-  const usedJSHeapSize: Ref<undefined | number> = ref(undefined);
-  const jsHeapSizeLimit: Ref<undefined | number> = ref(undefined);
+interface UseMemoryStatusOptions {
+  deviceMemory?: number;
+  totalJSHeapSize?: number;
+  usedJSHeapSize?: number;
+  jsHeapSizeLimit?: number;
+}
+
+export function useMemoryStatus(opts?: UseMemoryStatusOptions) {
+  const deviceMemory = ref(opts?.deviceMemory ?? undefined);
+  const totalJSHeapSize: Ref<undefined | number> = ref(opts?.totalJSHeapSize);
+  const usedJSHeapSize: Ref<undefined | number> = ref(opts?.usedJSHeapSize);
+  const jsHeapSizeLimit: Ref<undefined | number> = ref(opts?.jsHeapSizeLimit);
   const isSupported = ref(false);
 
   function resolveMemory() {

--- a/src/Network.ts
+++ b/src/Network.ts
@@ -4,14 +4,23 @@ import { isServer } from './utils';
 type NetworkType = 'bluetooth' | 'cellular' | 'ethernet' | 'none' | 'wifi' | 'wimax' | 'other' | 'unknown';
 type NetworkEffectiveType = 'slow-2g' | '2g' | '3g' | '4g' | undefined;
 
-export function useNetworkStatus() {
-  const isOnline = ref(true);
-  const saveData = ref(false);
+interface UseNetworkStatusOptions {
+  isOnline?: boolean;
+  saveData?: boolean;
+  downlink?: number;
+  downlinkMax?: number;
+  effectiveConnectionType?: NetworkEffectiveType;
+  networkType?: NetworkType;
+}
+
+export function useNetworkStatus(opts?: UseNetworkStatusOptions) {
+  const isOnline = ref(opts?.isOnline ?? true);
+  const saveData = ref(opts?.saveData ?? false);
   const offlineAt: Ref<number | undefined> = ref(undefined);
-  const downlink: Ref<number | undefined> = ref(undefined);
-  const downlinkMax: Ref<number | undefined> = ref(undefined);
-  const effectiveConnectionType: Ref<NetworkEffectiveType> = ref(undefined);
-  const networkType: Ref<NetworkType> = ref('unknown');
+  const downlink: Ref<number | undefined> = ref(opts?.downlink ?? undefined);
+  const downlinkMax: Ref<number | undefined> = ref(opts?.downlinkMax ?? undefined);
+  const effectiveConnectionType: Ref<NetworkEffectiveType> = ref(opts?.effectiveConnectionType ?? undefined);
+  const networkType: Ref<NetworkType> = ref(opts?.networkType ?? 'unknown');
   const isSupported = ref(false);
 
   function updateNetworkInformation() {

--- a/test/Battery.spec.ts
+++ b/test/Battery.spec.ts
@@ -50,6 +50,19 @@ describe('use Battery', () => {
     expect(vm.isSupported).toBe(false);
   });
 
+  test(`should return "false" for unsupported case but report initial values`, async () => {
+    Object.defineProperty(window, 'navigator', {
+      value: undefined,
+      configurable: true,
+      writable: true
+    });
+    const vm = mountHook(() => useBattery({ isCharging: true, chargingTime: 540 }));
+
+    expect(vm.isSupported).toBe(false);
+    expect(vm.isCharging).toBe(true);
+    expect(vm.chargingTime).toBe(540);
+  });
+
   test(`should return "true" for supported case`, async () => {
     Object.defineProperty(window.navigator, 'getBattery', {
       value: () =>

--- a/test/HardwareConcurrency.spec.ts
+++ b/test/HardwareConcurrency.spec.ts
@@ -21,6 +21,19 @@ describe('useHardwareConcurrency', () => {
     expect(vm.isSupported).toBe(false);
   });
 
+  test(`should return "false" for unsupported case but report the initial value`, async () => {
+    Object.defineProperty(window, 'navigator', {
+      value: undefined,
+      configurable: true,
+      writable: true
+    });
+
+    const vm = mountHook(() => useHardwareConcurrency(3));
+    expect(vm.concurrency).toBe(3);
+
+    expect(vm.isSupported).toBe(false);
+  });
+
   test(`should return "true" for supported case`, () => {
     const vm = mountHook(() => useHardwareConcurrency());
 

--- a/test/Memory.spec.ts
+++ b/test/Memory.spec.ts
@@ -16,6 +16,15 @@ describe('useMemoryStatus', () => {
     expect(vm.isSupported).toBe(false);
   });
 
+  test(`should return "false" for unsupported case but report initialMemoryStatus`, () => {
+    const vm = mountHook(() => useMemoryStatus({ deviceMemory: 3, usedJSHeapSize: 400 }));
+
+    expect(vm.isSupported).toBe(false);
+    expect(vm.deviceMemory).toBe(3);
+    expect(vm.usedJSHeapSize).toBe(400);
+    expect(vm.jsHeapSizeLimit).toBe(undefined);
+  });
+
   test('should return device memory for isSupported case', () => {
     const deviceMemory = 4;
     (global as any).navigator.deviceMemory = deviceMemory;

--- a/test/Network.spec.ts
+++ b/test/Network.spec.ts
@@ -34,6 +34,19 @@ describe('useNetworkStatus', () => {
     expect(vm.isSupported).toBe(false);
   });
 
+  test(`should return "false" for unsupported case but report initial values`, () => {
+    const vm = mountHook(() =>
+      useNetworkStatus({
+        saveData: true,
+        effectiveConnectionType: '3g'
+      })
+    );
+
+    expect(vm.isSupported).toBe(false);
+    expect(vm.saveData).toBe(true);
+    expect(vm.effectiveConnectionType).toBe('3g');
+  });
+
   test('should return 4g of effectiveConnectionType', () => {
     (global as any).navigator.connection = {
       ...fakeEventTarget,


### PR DESCRIPTION
Allows adding initial values to the available hooks, useful to provide assumptions about user device even if the assoicated APIs are not supported.

closes #3